### PR TITLE
Cleanup leaking (duplicate in region) resource groups in background thread and orphaned (no resources) ones at loadtime

### DIFF
--- a/SimpleWAWS/Code/BackgroundOperation.cs
+++ b/SimpleWAWS/Code/BackgroundOperation.cs
@@ -40,6 +40,7 @@ namespace SimpleWAWS.Code
         ResourceGroupDeleteThenCreate,
         ResourceGroupCreate,
         ResourceGroupPutInDesiredState,
-        LogUsageStatistics
+        LogUsageStatistics,
+        SubscriptionCleanup
     }
 }

--- a/SimpleWAWS/Code/BackgroundQueueManager.cs
+++ b/SimpleWAWS/Code/BackgroundQueueManager.cs
@@ -240,7 +240,8 @@ namespace SimpleWAWS.Code
             IList<Tuple<string,MakeSubscriptionFreeTrialResult>> subscriptionStates = new List<Tuple<string, MakeSubscriptionFreeTrialResult>>();
             foreach (var subscription in await CsmManager.GetSubscriptions())
             {
-                var trialsubresult = new Subscription(subscription).MakeTrialSubscription();
+                var sub = await new Subscription(subscription).Load(deleteBadResourceGroups: false);
+                var trialsubresult = sub.MakeTrialSubscription();
                 subscriptionStates.Add(new Tuple<string, MakeSubscriptionFreeTrialResult>(subscription, trialsubresult));
             }
             foreach (var state in subscriptionStates)
@@ -357,7 +358,7 @@ namespace SimpleWAWS.Code
 
         private void AddOperation<T>(BackgroundOperation<T> operation)
         {
-            if (BackgroundInternalOperations.Count > 70)
+            if (BackgroundInternalOperations.Count > SimpleSettings.BackGroundQueueSize)
             {
                 Task.Run(async () =>
                 {

--- a/SimpleWAWS/Code/BackgroundQueueManager.cs
+++ b/SimpleWAWS/Code/BackgroundQueueManager.cs
@@ -167,7 +167,7 @@ namespace SimpleWAWS.Code
                     break;
 
                 case OperationType.ResourceGroupDelete:
-                    var rgToRemove = (ResourceGroup)resourceGroupTask.RetryAction.Target;
+                    var rgToRemove = resourceGroupTask.Task.Result;
                     DeleteResourceGroupOperation(rgToRemove);
 
                     // Now Remove from Free queues if it is present there

--- a/SimpleWAWS/Code/BackgroundQueueManager.cs
+++ b/SimpleWAWS/Code/BackgroundQueueManager.cs
@@ -167,7 +167,24 @@ namespace SimpleWAWS.Code
                     break;
 
                 case OperationType.ResourceGroupDelete:
-                        DeleteResourceGroupOperation(resourceGroupTask.Task.Result);
+                    var rgToRemove = resourceGroupTask.Task.Result;
+                        DeleteResourceGroupOperation(rgToRemove);
+
+                    // Now Remove from Free queues if it is present there
+                    ResourceGroup tempRg;
+                    while (FreeResourceGroups.TryDequeue(out tempRg)){
+                        if (tempRg.CsmId != rgToRemove.CsmId)
+                        {
+                            FreeResourceGroups.Enqueue(tempRg);
+                        }
+                    }
+                    while (FreeJenkinsResourceGroups.TryDequeue(out tempRg))
+                    {
+                        if (tempRg.CsmId != rgToRemove.CsmId)
+                        {
+                            FreeJenkinsResourceGroups.Enqueue(tempRg);
+                        }
+                    }
                     break;
                 default:
                     break;

--- a/SimpleWAWS/Code/BackgroundQueueManager.cs
+++ b/SimpleWAWS/Code/BackgroundQueueManager.cs
@@ -32,15 +32,15 @@ namespace SimpleWAWS.Code
         {
             if (_maintainResourceGroupTimer == null)
             {
-                _maintainResourceGroupTimer = new Timer(OnMaintainResourceGroupTimerElapsed, null, TimeSpan.FromMinutes(1), TimeSpan.FromMilliseconds(SimpleSettings.MaintainResourceGroupsMinutes * 60 * 1000));
+                _maintainResourceGroupTimer = new Timer(OnMaintainResourceGroupTimerElapsed, null, TimeSpan.FromMinutes(SimpleSettings.MaintainResourceGroupsMinutes), TimeSpan.FromMinutes(SimpleSettings.MaintainResourceGroupsMinutes));
             }
             if (_logQueueStatsTimer == null)
             {
-                _logQueueStatsTimer = new Timer(OnLogQueueStatsTimerElapsed, null, TimeSpan.FromMinutes(1), TimeSpan.FromMilliseconds(SimpleSettings.LoqQueueStatsMinutes * 60 * 1000));
+                _logQueueStatsTimer = new Timer(OnLogQueueStatsTimerElapsed, null, TimeSpan.FromMinutes(SimpleSettings.LoqQueueStatsMinutes), TimeSpan.FromMinutes(SimpleSettings.LoqQueueStatsMinutes));
             }
             if (_cleanupSubscriptionsTimer == null)
             {
-                _cleanupSubscriptionsTimer = new Timer(OnCleanupSubscriptionsTimerElapsed, null, TimeSpan.FromMinutes(1), TimeSpan.FromMilliseconds(SimpleSettings.CleanupSubscriptionMinutes * 60 * 1000));
+                _cleanupSubscriptionsTimer = new Timer(OnCleanupSubscriptionsTimerElapsed, null, TimeSpan.FromMinutes(SimpleSettings.CleanupSubscriptionMinutes), TimeSpan.FromMinutes(SimpleSettings.CleanupSubscriptionMinutes));
             }
         }
 

--- a/SimpleWAWS/Code/BackgroundQueueManager.cs
+++ b/SimpleWAWS/Code/BackgroundQueueManager.cs
@@ -274,7 +274,7 @@ namespace SimpleWAWS.Code
             } 
         }
 
-        private void RemoveFromFreeJenkinsQueue(ResourceGroup resourceGroup)
+        private void RemoveFromFreeAppServiceQueue(ResourceGroup resourceGroup)
         {
             var dequeueCount = this.FreeResourceGroups.Count;
             ResourceGroup temp;
@@ -291,7 +291,7 @@ namespace SimpleWAWS.Code
             }
         }
 
-        private void RemoveFromFreeAppServiceQueue(ResourceGroup resourceGroup)
+        private void RemoveFromFreeJenkinsQueue(ResourceGroup resourceGroup)
         {
             var dequeueCount = this.FreeJenkinsResourceGroups.Count;
             ResourceGroup temp;

--- a/SimpleWAWS/Code/BackgroundQueueManager.cs
+++ b/SimpleWAWS/Code/BackgroundQueueManager.cs
@@ -167,7 +167,7 @@ namespace SimpleWAWS.Code
                     break;
 
                 case OperationType.ResourceGroupDelete:
-                    var rgToRemove = resourceGroupTask.Task.Result;
+                    var rgToRemove = (ResourceGroup)resourceGroupTask.RetryAction.Target;
                     DeleteResourceGroupOperation(rgToRemove);
 
                     // Now Remove from Free queues if it is present there
@@ -229,10 +229,7 @@ namespace SimpleWAWS.Code
         {
             var resources = this.ResourceGroupsInUse
                 .Select(e => e.Value)
-                .Where(rg => (int)rg.TimeLeft.TotalSeconds == 0)
-                .Union(this.ResourceGroupsInUse
-                .Select(e => e.Value)
-                .Where(rg => (int)rg.TimeLeft.TotalSeconds == 0));
+                .Where(rg => (int)rg.TimeLeft.TotalSeconds == 0);
 
             foreach (var resource in resources)
                 DeleteResourceGroup(resource);

--- a/SimpleWAWS/Code/BackgroundQueueManager.cs
+++ b/SimpleWAWS/Code/BackgroundQueueManager.cs
@@ -32,18 +32,15 @@ namespace SimpleWAWS.Code
         {
             if (_maintainResourceGroupTimer == null)
             {
-                _maintainResourceGroupTimer = new Timer(OnMaintainResourceGroupTimerElapsed);
-                _maintainResourceGroupTimer.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(SimpleSettings.MaintainResourceGroupsMinutes * 60 * 1000));
+                _maintainResourceGroupTimer = new Timer(OnMaintainResourceGroupTimerElapsed, null, TimeSpan.FromMinutes(1), TimeSpan.FromMilliseconds(SimpleSettings.MaintainResourceGroupsMinutes * 60 * 1000));
             }
             if (_logQueueStatsTimer == null)
             {
-                _logQueueStatsTimer = new Timer(OnLogQueueStatsTimerElapsed);
-                _logQueueStatsTimer.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(SimpleSettings.LoqQueueStatsMinutes * 60 * 1000));
+                _logQueueStatsTimer = new Timer(OnLogQueueStatsTimerElapsed, null, TimeSpan.FromMinutes(1), TimeSpan.FromMilliseconds(SimpleSettings.LoqQueueStatsMinutes * 60 * 1000));
             }
             if (_cleanupSubscriptionsTimer == null)
             {
-                _cleanupSubscriptionsTimer = new Timer(OnCleanupSubscriptionsTimerElapsed);
-                _cleanupSubscriptionsTimer.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(SimpleSettings.CleanupSubscriptionMinutes * 60 * 1000));
+                _cleanupSubscriptionsTimer = new Timer(OnCleanupSubscriptionsTimerElapsed, null, TimeSpan.FromMinutes(1), TimeSpan.FromMilliseconds(SimpleSettings.CleanupSubscriptionMinutes * 60 * 1000));
             }
         }
 
@@ -274,7 +271,7 @@ namespace SimpleWAWS.Code
             var inUseWebsitesCount = resourceGroups.Count(res => res.AppService == AppService.Web);
             var inUseMobileCount = resourceGroups.Count(res => res.AppService == AppService.Mobile);
             var inUseLogicAppCount = resourceGroups.Count(res => res.AppService == AppService.Logic);
-            //            var inUseApiAppCount = resourceGroups.Count(res => res.AppService == AppService.Api);
+            var inUseApiAppCount = resourceGroups.Count(res => res.AppService == AppService.Api);
             var inProgress = ResourceGroupsInProgress.Select(s => s.Value).Count();
             var backgroundOperations = BackgroundInternalOperations.Select(s => s.Value).Count();
             var freeJenkinsResources = FreeJenkinsResourceGroups.Count(sub => sub.SubscriptionType == SubscriptionType.Jenkins);
@@ -286,7 +283,7 @@ namespace SimpleWAWS.Code
             AppInsights.TelemetryClient.TrackMetric("inUseWebsitesCount", inUseWebsitesCount);
             AppInsights.TelemetryClient.TrackMetric("inUseMobileCount", inUseMobileCount);
             AppInsights.TelemetryClient.TrackMetric("inUseLogicAppCount", inUseLogicAppCount);
-            //            AppInsights.TelemetryClient.TrackMetric("inUseApiAppCount", inUseApiAppCount);
+            AppInsights.TelemetryClient.TrackMetric("inUseApiAppCount", inUseApiAppCount);
             AppInsights.TelemetryClient.TrackMetric("inUseSites", inUseSitesCount);
 
             AppInsights.TelemetryClient.TrackMetric("inProgressOperations", inProgress);

--- a/SimpleWAWS/Code/CsmExtensions/CsmResourceGroupExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmResourceGroupExtensions.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using SimpleWAWS.Models;
 using SimpleWAWS.Models.CsmModels;
+using SimpleWAWS.Trace;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -370,8 +371,10 @@ namespace SimpleWAWS.Code.CsmExtensions
                     && csmResourceGroup.tags.ContainsKey(Constants.LifeTimeInMinutes)
                     && DateTime.UtcNow > DateTime.Parse(csmResourceGroup.tags[Constants.StartTime]).AddMinutes(Int32.Parse(csmResourceGroup.tags[Constants.LifeTimeInMinutes]));
             }
-            catch {
-                //Assume resoourcegroup is in a bad state.
+            catch (Exception ex)
+            {
+                //Assume resourcegroup is in a bad state.
+                SimpleTrace.Diagnostics.Fatal("ResourceGroup in bad state {@exception}", ex);
                 return false;
             }
         }

--- a/SimpleWAWS/Code/CsmExtensions/CsmResourceGroupExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmResourceGroupExtensions.cs
@@ -361,7 +361,7 @@ namespace SimpleWAWS.Code.CsmExtensions
 
         private static bool IsJenkinsResource(CsmWrapper<CsmResourceGroup> csmResourceGroup)
         {
-            return IsSimpleWawsResourceName(csmResourceGroup) && &&
+            return IsSimpleWawsResourceName(csmResourceGroup) &&
                 csmResourceGroup.properties.provisioningState == "Succeeded" &&
                 csmResourceGroup.tags != null && !csmResourceGroup.tags.ContainsKey("Bad") 
                 && csmResourceGroup.tags.ContainsKey(Constants.SubscriptionType)

--- a/SimpleWAWS/Code/CsmExtensions/CsmResourceGroupExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmResourceGroupExtensions.cs
@@ -348,16 +348,20 @@ namespace SimpleWAWS.Code.CsmExtensions
         }
         private static bool IsSimpleWaws(CsmWrapper<CsmResourceGroup> csmResourceGroup)
         {
-            return !string.IsNullOrEmpty(csmResourceGroup.name) &&
-                csmResourceGroup.name.StartsWith(Constants.TryResourceGroupPrefix, StringComparison.OrdinalIgnoreCase) &&
+            return IsSimpleWawsResourceName(csmResourceGroup) &&
                 csmResourceGroup.properties.provisioningState == "Succeeded" &&
                 csmResourceGroup.tags != null && !csmResourceGroup.tags.ContainsKey("Bad")
                 && csmResourceGroup.tags.ContainsKey("FunctionsContainerDeployed");
         }
-        private static bool IsJenkinsResource(CsmWrapper<CsmResourceGroup> csmResourceGroup)
+        private static bool IsSimpleWawsResourceName(CsmWrapper<CsmResourceGroup> csmResourceGroup)
         {
             return !string.IsNullOrEmpty(csmResourceGroup.name) &&
-                csmResourceGroup.name.StartsWith(Constants.TryResourceGroupPrefix, StringComparison.OrdinalIgnoreCase) &&
+                csmResourceGroup.name.StartsWith(Constants.TryResourceGroupPrefix, StringComparison.OrdinalIgnoreCase) ;
+        }
+
+        private static bool IsJenkinsResource(CsmWrapper<CsmResourceGroup> csmResourceGroup)
+        {
+            return IsSimpleWawsResourceName(csmResourceGroup) && &&
                 csmResourceGroup.properties.provisioningState == "Succeeded" &&
                 csmResourceGroup.tags != null && !csmResourceGroup.tags.ContainsKey("Bad") 
                 && csmResourceGroup.tags.ContainsKey(Constants.SubscriptionType)

--- a/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
@@ -80,7 +80,13 @@ namespace SimpleWAWS.Code.CsmExtensions
                     .Select( async r => await Load(new ResourceGroup(subscription.SubscriptionId, r.ResourceGroup.name),r.ResourceGroup, r.Resources))
                     .IgnoreAndFilterFailures();
 
-                return subscription;
+            if (deleteBadResourceGroups)
+            {
+                var deleteDuplicateResourceGroupsTasks = goodResourceGroups.Where(p => !subscription.ResourceGroups.Any(p2 => p2.CsmId == p.ResourceGroup.id))
+                    .Select(async r => await Delete(await Load(new ResourceGroup(subscription.SubscriptionId, r.ResourceGroup.name), r.ResourceGroup, loadSubResources: false), block: false));
+                await deleteDuplicateResourceGroupsTasks.IgnoreFailures().WhenAll();
+            }
+            return subscription;
 
         }
 

--- a/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
@@ -31,9 +31,9 @@ namespace SimpleWAWS.Code.CsmExtensions
                         //Some orphaned resourcegroups can have no tags. Okay to clean once in a while since they dont have any sites either
                         .Where(r =>   ((r.tags == null && IsSimpleWawsResourceName(r)) 
                                     || (r.tags != null && ((r.tags.ContainsKey("Bad") ||
-                                       (subscription.Type == SubscriptionType.AppService ? !r.tags.ContainsKey("FunctionsContainerDeployed") : !r.tags.ContainsKey(Constants.SubscriptionType)))
+                                       (subscription.Type==SubscriptionType.AppService?!r.tags.ContainsKey("FunctionsContainerDeployed"):!r.tags.ContainsKey(Constants.SubscriptionType)))
                                         )) 
-                                        && r.properties.provisioningState != "Deleting"))
+                                        && r.properties.provisioningState != "Deleting")) 
                         .Select(async r => await Delete(await Load(new ResourceGroup(subscription.SubscriptionId, r.name), r, loadSubResources: false), block: false));
               
                     await deleteBadResourceGroupsTasks.IgnoreFailures().WhenAll();

--- a/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
@@ -11,10 +11,10 @@ namespace SimpleWAWS.Code.CsmExtensions
 {
     public static partial class CsmManager
     {
-        
-        public static async Task<Subscription> SubscriptionCleanup(this Subscription subscription) {
-            return await Load(subscription, deleteBadResourceGroups: true);
 
+        public static async Task<Subscription> SubscriptionCleanup(this Subscription subscription)
+        {
+            return await Load(subscription, deleteBadResourceGroups: true);
         }
         public static async Task<Subscription> Load(this Subscription subscription, bool deleteBadResourceGroups = true)
         {

--- a/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
@@ -31,8 +31,9 @@ namespace SimpleWAWS.Code.CsmExtensions
                         //Some orphaned resourcegroups can have no tags. Okay to clean once in a while since they dont have any sites either
                         .Where(r =>   ((r.tags == null && IsSimpleWawsResourceName(r)) 
                                     || (r.tags != null && ((r.tags.ContainsKey("Bad") ||
-                                       (subscription.Type == SubscriptionType.AppService ? !r.tags.ContainsKey("FunctionsContainerDeployed") : !r.tags.ContainsKey(Constants.SubscriptionType))))) 
-                                    &&  r.properties.provisioningState != "Deleting"))
+                                       (subscription.Type == SubscriptionType.AppService ? !r.tags.ContainsKey("FunctionsContainerDeployed") : !r.tags.ContainsKey(Constants.SubscriptionType)))
+                                        )) 
+                                        && r.properties.provisioningState != "Deleting"))
                         .Select(async r => await Delete(await Load(new ResourceGroup(subscription.SubscriptionId, r.name), r, loadSubResources: false), block: false));
               
                     await deleteBadResourceGroupsTasks.IgnoreFailures().WhenAll();

--- a/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
@@ -50,7 +50,7 @@ namespace SimpleWAWS.Code.CsmExtensions
                     await csmSubscriptionResourcesReponse.Content.ReadAsAsync<CsmArrayWrapper<object>>();
 
                 var goodResourceGroups = csmResourceGroups.value
-                    .Where(r => subscription.Type==SubscriptionType.AppService?IsSimpleWaws(r): IsJenkinsResource(r))
+                    .Where(r => subscription.Type == SubscriptionType.AppService?IsSimpleWaws(r) : IsJenkinsResource(r))
                     .Select(r => new
                     {
                         ResourceGroup = r,

--- a/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
+++ b/SimpleWAWS/Code/CsmExtensions/CsmSubscriptionExtensions.cs
@@ -33,7 +33,7 @@ namespace SimpleWAWS.Code.CsmExtensions
                                     || (r.tags != null && ((r.tags.ContainsKey("Bad") ||
                                        (subscription.Type==SubscriptionType.AppService?!r.tags.ContainsKey("FunctionsContainerDeployed"):!r.tags.ContainsKey(Constants.SubscriptionType)))
                                         )) 
-                                        && r.properties.provisioningState != "Deleting")) 
+                                    && r.properties.provisioningState != "Deleting")) 
                         .Select(async r => await Delete(await Load(new ResourceGroup(subscription.SubscriptionId, r.name), r, loadSubResources: false), block: false));
               
                     await deleteBadResourceGroupsTasks.IgnoreFailures().WhenAll();

--- a/SimpleWAWS/Code/ResourcesManager.cs
+++ b/SimpleWAWS/Code/ResourcesManager.cs
@@ -57,24 +57,7 @@ namespace SimpleWAWS.Code
         // ARM
         private async Task LoadAzureResources()
         {
-            // Load all subscriptions
-            var csmSubscriptions = await CsmManager.GetSubscriptionNamesToIdMap();
-            var subscriptions = (SimpleSettings.Subscriptions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                .Union(SimpleSettings.JenkinsSubscriptions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)))
-                //It can be either a displayName or a subscriptionId
-                //For Jenkins it needs to be subscriptionId
-                .Select(s => s.Trim())
-                .Where(n =>
-                {
-                    Guid temp;
-                    return csmSubscriptions.ContainsKey(n) || Guid.TryParse(n, out temp);
-                })
-                .Select(sn =>
-                {
-                    Guid temp;
-                    if (Guid.TryParse(sn, out temp)) return sn;
-                    else return csmSubscriptions[sn];
-                });
+            var subscriptions = await CsmManager.GetSubscriptions();
             HostingEnvironment.QueueBackgroundWorkItem(_ =>
             {
                 foreach (var subscription in subscriptions)

--- a/SimpleWAWS/Code/SimpleSettings.cs
+++ b/SimpleWAWS/Code/SimpleSettings.cs
@@ -55,6 +55,7 @@ namespace SimpleWAWS.Code
         public static string ZippedRepoUrl { get { return config(); } }
         public static int CleanupSubscriptionMinutes { get { return Int32.Parse(config("77")); } }
         public static int LoqQueueStatsMinutes { get { return Int32.Parse(config("5")); } }
-        public static int MaintainResourceGroupsMinutes { get { return Int32.Parse(config("30")); } }
+        public static int MaintainResourceGroupsMinutes { get { return Int32.Parse(config("31")); } }
+        public static int BackGroundQueueSize{ get { return Int32.Parse(config("50")); } }
     }
 }   

--- a/SimpleWAWS/Code/SimpleSettings.cs
+++ b/SimpleWAWS/Code/SimpleSettings.cs
@@ -53,5 +53,8 @@ namespace SimpleWAWS.Code
         public static string GraphUserName { get { return config(); } }
         public static string GraphPassword { get { return config(); } }
         public static string ZippedRepoUrl { get { return config(); } }
+        public static int CleanupSubscriptionMinutes { get { return Int32.Parse(config("60")); } }
+        public static int LoqQueueStatsMinutes { get { return Int32.Parse(config("5")); } }
+        public static int MaintainResourceGroupsMinutes { get { return Int32.Parse(config("1")); } }
     }
 }   

--- a/SimpleWAWS/Code/SimpleSettings.cs
+++ b/SimpleWAWS/Code/SimpleSettings.cs
@@ -53,8 +53,8 @@ namespace SimpleWAWS.Code
         public static string GraphUserName { get { return config(); } }
         public static string GraphPassword { get { return config(); } }
         public static string ZippedRepoUrl { get { return config(); } }
-        public static int CleanupSubscriptionMinutes { get { return Int32.Parse(config("60")); } }
+        public static int CleanupSubscriptionMinutes { get { return Int32.Parse(config("77")); } }
         public static int LoqQueueStatsMinutes { get { return Int32.Parse(config("5")); } }
-        public static int MaintainResourceGroupsMinutes { get { return Int32.Parse(config("1")); } }
+        public static int MaintainResourceGroupsMinutes { get { return Int32.Parse(config("30")); } }
     }
 }   

--- a/SimpleWAWS/Models/ResourceGroup.cs
+++ b/SimpleWAWS/Models/ResourceGroup.cs
@@ -178,7 +178,7 @@ namespace SimpleWAWS.Models
                         ibizaUrl = siteToUseForUi.IbizaUrl;
                         break;
                     case Models.AppService.Logic:
-                        ibizaUrl = LogicApps.First().IbizaUrl;
+                        ibizaUrl = LogicApps.First()?.IbizaUrl;
                         break;
                     case Models.AppService.Function:
                         csmId = Sites.First(s => s.IsFunctionsContainer).CsmId;

--- a/SimpleWAWS/Models/ResourceGroup.cs
+++ b/SimpleWAWS/Models/ResourceGroup.cs
@@ -144,12 +144,19 @@ namespace SimpleWAWS.Models
         {
             get
             {
-                return !string.IsNullOrEmpty(ResourceGroupName) && ResourceGroupName.StartsWith(Constants.TryResourceGroupPrefix, StringComparison.InvariantCulture)
+                return IsSimpleWAWSResourceName
                  && Tags != null && !Tags.ContainsKey("Bad")
                 && Tags.ContainsKey("FunctionsContainerDeployed");
             }
         }
-
+        public bool IsSimpleWAWSResourceName
+        {
+            get
+            {
+                return !string.IsNullOrEmpty(ResourceGroupName) && ResourceGroupName.StartsWith(Constants.TryResourceGroupPrefix, StringComparison.InvariantCulture)
+;
+            }
+        }
         public UIResource UIResource
         {
             get

--- a/SimpleWAWS/Models/ResourceGroup.cs
+++ b/SimpleWAWS/Models/ResourceGroup.cs
@@ -178,7 +178,7 @@ namespace SimpleWAWS.Models
                         ibizaUrl = siteToUseForUi.IbizaUrl;
                         break;
                     case Models.AppService.Logic:
-                        ibizaUrl = LogicApps.First()?.IbizaUrl;
+                        ibizaUrl = LogicApps.Any()?LogicApps.First().IbizaUrl : null;
                         break;
                     case Models.AppService.Function:
                         csmId = Sites.First(s => s.IsFunctionsContainer).CsmId;

--- a/SimpleWAWS/Models/ResourceGroup.cs
+++ b/SimpleWAWS/Models/ResourceGroup.cs
@@ -45,7 +45,7 @@ namespace SimpleWAWS.Models
 
         public TimeSpan LifeTime
         {
-            get { return TimeSpan.FromMinutes(int.Parse(Tags[Constants.LifeTimeInMinutes])); }
+            get { return TimeSpan.FromMinutes(int.Parse(Tags.ContainsKey(Constants.UserId) ? Tags[Constants.LifeTimeInMinutes] : "0" )); }
         }
 
         public static readonly TimeSpan DefaultUsageTimeSpan = TimeSpan.FromMinutes(int.Parse(SimpleSettings.SiteExpiryMinutes, CultureInfo.InvariantCulture));


### PR DESCRIPTION
Make it easy to manage resources and curb abuse